### PR TITLE
Serve built frontend from Flask backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,20 @@ A comprehensive environmental polygon scoring system that analyzes temperature, 
 ## 🚀 Quick Start
 
 ```bash
-# Install dependencies
+# Install Python dependencies
 pip install -r requirements.txt
 
-# Run the polygon scoring system
-python polygon_scoring_system.py
+# Install frontend dependencies and build the production bundle
+cd my-app
+npm install
+npm run build
+cd ..
+
+# Start the Flask backend (serves APIs and the built frontend)
+python backend_server.py
 ```
+
+The Flask server now hosts the compiled React app from `my-app/dist`, so once it is running you can navigate to `http://localhost:5001` to interact with the frontend and API together.
 
 ## 📁 Project Structure
 

--- a/backend_server.py
+++ b/backend_server.py
@@ -11,6 +11,9 @@ import os
 app = Flask(__name__)
 CORS(app)  # Enable CORS for frontend access
 
+
+DIST_DIR = os.path.join(os.path.dirname(__file__), 'my-app', 'dist')
+
 @app.route('/api/polygon-scores')
 def get_polygon_scores():
     """Serve the polygon scoring results."""
@@ -35,6 +38,20 @@ def get_regions():
 def health_check():
     """Health check endpoint."""
     return jsonify({'status': 'healthy', 'message': 'Backend API is running'})
+
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def serve_frontend(path):
+    """Serve the built frontend assets, falling back to index.html for SPA routing."""
+    if not os.path.exists(DIST_DIR):
+        return jsonify({'error': 'Frontend build directory not found'}), 500
+
+    # Serve the requested asset if it exists, otherwise return the SPA entry point.
+    file_path = os.path.join(DIST_DIR, path)
+    if path and os.path.isfile(file_path):
+        return send_from_directory(DIST_DIR, path)
+    return send_from_directory(DIST_DIR, 'index.html')
 
 if __name__ == '__main__':
     print("🚀 Starting backend server...")


### PR DESCRIPTION
## Summary
- add a catch-all Flask route that serves the built React app from `my-app/dist`
- document the workflow for building the frontend and running the backend together in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2111d8a148328b4998cf0a0fa6509