### PR TITLE
Add FastAPI backend for park impact simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Healthy City Score backend package."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,232 @@
+"""FastAPI backend for park impact simulation and scoring."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import rioxarray as rxr
+import xarray as xr
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+from rasterio.features import rasterize
+from rasterio.transform import from_bounds
+from shapely.geometry import shape
+
+from .utils.optimize import greedy_search
+from .utils.scoring import ScoreSummary, compute_hcs, equity_adjust
+from .utils.simulation import SimulationResult, simulate_park
+
+BOUNDS = {
+    "west": -87.8,
+    "south": 41.8,
+    "east": -87.5,
+    "north": 42.1,
+}
+DEFAULT_SHAPE = (60, 60)
+CRS = "EPSG:4326"
+
+app = FastAPI(title="Healthy City Score API", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ParkRequest(BaseModel):
+    polygon: Dict[str, Any] = Field(..., description="GeoJSON geometry for the new park")
+    lambda_m: float = Field(0.5, description="Maintenance penalty")
+    lambda_o: float = Field(2.0, description="Overlap penalty multiplier")
+    service_radius: float = Field(300.0, description="Service radius in metres")
+
+
+class OptimisationRequest(BaseModel):
+    candidate_count: int = Field(25, ge=1, le=500)
+    max_iterations: int = Field(12, ge=1, le=100)
+    kernel_size: int = Field(3, ge=1, le=11)
+    lambda_m: float = Field(0.5)
+    lambda_o: float = Field(2.0)
+
+
+def _mock_surface(name: str, shape: tuple[int, int]) -> xr.DataArray:
+    rng = np.random.default_rng(abs(hash(name)) & 0xFFFFFFFF)
+    rows, cols = shape
+    yy, xx = np.indices(shape)
+    centre_y, centre_x = rows / 2.0, cols / 2.0
+    distance = np.sqrt((yy - centre_y) ** 2 + (xx - centre_x) ** 2)
+    distance_norm = distance / distance.max()
+
+    if name == "lst.tif":
+        data = 32 + 4 * distance_norm + rng.normal(0, 0.4, shape)
+    elif name == "no2.tif":
+        data = 0.03 + 0.02 * (1 - distance_norm) + rng.normal(0, 0.002, shape)
+        data = np.clip(data, 0.005, None)
+    elif name == "pwv.tif":
+        data = 3 + 0.3 * rng.normal(0, 1, shape)
+    elif name == "pop.tif":
+        data = 2000 * (1 - distance_norm) + 100 * rng.random(shape)
+        data = np.clip(data, 0, None)
+    elif name == "vuln.tif":
+        data = np.clip(0.6 * (1 - distance_norm) + 0.3 * rng.random(shape), 0, 1)
+    elif name == "parks_existing.tif":
+        data = np.zeros(shape, dtype=float)
+        data[5:12, 8:14] = 1
+        data[35:42, 30:36] = 1
+    else:
+        data = rng.random(shape)
+
+    return _dataarray_from_data(data)
+
+
+def _dataarray_from_data(data: np.ndarray) -> xr.DataArray:
+    rows, cols = data.shape
+    pixel_width = (BOUNDS["east"] - BOUNDS["west"]) / cols
+    pixel_height = (BOUNDS["north"] - BOUNDS["south"]) / rows
+    x_coords = BOUNDS["west"] + pixel_width / 2 + pixel_width * np.arange(cols)
+    y_coords = BOUNDS["north"] - pixel_height / 2 - pixel_height * np.arange(rows)
+    da = xr.DataArray(data, coords={"y": y_coords, "x": x_coords}, dims=("y", "x"))
+    da = da.rio.write_crs(CRS)
+    transform = from_bounds(
+        BOUNDS["west"], BOUNDS["south"], BOUNDS["east"], BOUNDS["north"], cols, rows
+    )
+    da.rio.write_transform(transform, inplace=True)
+    return da
+
+
+def _load_raster(path: Path, fallback_name: str, shape: tuple[int, int]) -> xr.DataArray:
+    if path.exists():
+        da = rxr.open_rasterio(path).squeeze()
+        if "band" in da.dims:
+            da = da.drop("band")
+        return da
+    return _mock_surface(fallback_name, shape)
+
+
+@app.on_event("startup")
+def load_rasters() -> None:
+    data_dir = Path(__file__).resolve().parent / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    shape = DEFAULT_SHAPE
+
+    lst = _load_raster(data_dir / "lst.tif", "lst.tif", shape)
+    shape = lst.shape
+
+    no2 = _load_raster(data_dir / "no2.tif", "no2.tif", shape)
+    pwv = _load_raster(data_dir / "pwv.tif", "pwv.tif", shape)
+    pop = _load_raster(data_dir / "pop.tif", "pop.tif", shape)
+    vuln = _load_raster(data_dir / "vuln.tif", "vuln.tif", shape)
+    parks = _load_raster(data_dir / "parks_existing.tif", "parks_existing.tif", shape)
+
+    app.state.lst = lst
+    app.state.no2 = no2
+    app.state.pwv = pwv
+    app.state.pop = pop
+    app.state.vuln = vuln
+    app.state.parks = parks.astype(bool)
+
+
+def _geometry_to_mask(geom: Any, template: xr.DataArray) -> np.ndarray:
+    transform = template.rio.transform()
+    out_shape = template.shape
+    mask = rasterize([(geom, 1)], out_shape=out_shape, transform=transform, fill=0)
+    return mask.astype(bool)
+
+
+def _simulation_payload(result: SimulationResult) -> Dict[str, Any]:
+    mean_lst = float(np.nanmean(result.delta_lst))
+    min_lst = float(np.nanmin(result.delta_lst))
+    mean_no2 = float(np.nanmean(result.delta_no2))
+    total_coverage_gain = float(np.nanmean(np.clip(result.coverage_gain, 0.0, 1.0)))
+
+    delta_hcs = float(np.nanmean(result.hcs_after - result.hcs_before))
+
+    return {
+        "delta_hcs": delta_hcs,
+        "delta_equity": result.mean_equity_delta,
+        "marginal_gain": result.marginal_gain,
+        "maintenance_penalty": result.maintenance_penalty,
+        "overlap_penalty": result.overlap_penalty,
+        "coverage_gain": total_coverage_gain,
+        "max_cooling": abs(min_lst),
+        "mean_cooling": abs(mean_lst),
+        "mean_no2_change_pct": -100.0 * mean_no2 / (np.nanmean(app.state.no2.values) + 1e-9),
+        "coverage_before_mean": float(np.nanmean(result.coverage_before)),
+        "coverage_after_mean": float(np.nanmean(result.coverage_after)),
+    }
+
+
+@app.get("/score")
+def score() -> Dict[str, float]:
+    lst = app.state.lst.values
+    no2 = app.state.no2.values
+    pwv = app.state.pwv.values
+    vuln = app.state.vuln.values
+
+    hcs = compute_hcs(lst, no2, pwv)
+    equity = equity_adjust(hcs, vuln)
+    summary = ScoreSummary.from_surfaces(hcs, equity)
+    return {"hcs_mean": summary.hcs_mean, "equity_mean": summary.equity_mean}
+
+
+@app.post("/simulate/park")
+def simulate_park_endpoint(req: ParkRequest) -> Dict[str, Any]:
+    try:
+        geom = shape(req.polygon)
+    except Exception as exc:  # pragma: no cover - shapely validation
+        raise HTTPException(status_code=400, detail=f"Invalid geometry: {exc}") from exc
+
+    template = app.state.lst
+    mask = _geometry_to_mask(geom, template)
+    if not mask.any():
+        raise HTTPException(status_code=400, detail="Polygon does not intersect the study area")
+
+    result = simulate_park(
+        app.state.lst.values,
+        app.state.no2.values,
+        app.state.pwv.values,
+        app.state.pop.values,
+        app.state.vuln.values,
+        app.state.parks.values,
+        mask,
+        service_radius=req.service_radius,
+        lambda_m=req.lambda_m,
+        lambda_o=req.lambda_o,
+    )
+
+    if result is None:
+        raise HTTPException(status_code=400, detail="Polygon overlaps existing parks only")
+
+    payload = _simulation_payload(result)
+    payload["message"] = (
+        "Park cools up to "
+        f"{payload['max_cooling']:.2f}°C and reduces NO₂ by {payload['mean_no2_change_pct']:.1f}% "
+        f"(equity-adjusted ΔHCS: {payload['delta_equity']:.2f})."
+    )
+    return payload
+
+
+@app.post("/optimize")
+def optimise_endpoint(req: OptimisationRequest) -> Dict[str, Any]:
+    result = greedy_search(
+        app.state.lst.values,
+        app.state.no2.values,
+        app.state.pwv.values,
+        app.state.pop.values,
+        app.state.vuln.values,
+        app.state.parks.values,
+        candidate_count=req.candidate_count,
+        max_iterations=req.max_iterations,
+        kernel_size=req.kernel_size,
+        lambda_m=req.lambda_m,
+        lambda_o=req.lambda_o,
+    )
+    return result.as_dict()
+
+
+@app.get("/")
+def root() -> Dict[str, Any]:
+    return {"message": "Healthy City Score API ready"}

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the Healthy City Score backend."""

--- a/backend/utils/optimize.py
+++ b/backend/utils/optimize.py
@@ -1,0 +1,128 @@
+"""Greedy optimiser to determine the optimal number of parks."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+from .scoring import ScoreSummary
+from .simulation import SimulationResult, make_structured_candidate, simulate_park
+
+
+@dataclass
+class OptimisationStep:
+    index: int
+    equity_delta: float
+    marginal_gain: float
+    coverage_gain: float
+    maintenance_penalty: float
+    overlap_penalty: float
+    summary: ScoreSummary
+
+
+@dataclass
+class OptimisationResult:
+    steps: List[OptimisationStep]
+
+    @property
+    def optimal_parks(self) -> int:
+        return len(self.steps)
+
+    def as_dict(self) -> dict:
+        return {
+            "optimal_parks": self.optimal_parks,
+            "steps": [
+                {
+                    "index": step.index,
+                    "equity_delta": step.equity_delta,
+                    "marginal_gain": step.marginal_gain,
+                    "coverage_gain": step.coverage_gain,
+                    "maintenance_penalty": step.maintenance_penalty,
+                    "overlap_penalty": step.overlap_penalty,
+                    "hcs_mean": step.summary.hcs_mean,
+                    "equity_mean": step.summary.equity_mean,
+                }
+                for step in self.steps
+            ],
+        }
+
+
+def greedy_search(
+    lst: np.ndarray,
+    no2: np.ndarray,
+    pwv: np.ndarray,
+    pop: np.ndarray,
+    vulnerability: np.ndarray,
+    parks_mask: np.ndarray,
+    *,
+    candidate_count: int = 25,
+    max_iterations: int = 12,
+    kernel_size: int = 3,
+    lambda_m: float = 0.5,
+    lambda_o: float = 2.0,
+) -> OptimisationResult:
+    """Greedy search to determine when parks stop improving the score."""
+
+    current_lst = np.array(lst, copy=True)
+    current_no2 = np.array(no2, copy=True)
+    current_pw = np.array(pwv, copy=True)
+    current_parks = parks_mask.astype(bool).copy()
+
+    steps: List[OptimisationStep] = []
+
+    flat_indices = np.arange(current_parks.size)
+
+    for iteration in range(max_iterations):
+        need_surface = np.nan_to_num(pop) * (1.0 + np.nan_to_num(vulnerability))
+        need_surface[current_parks] = 0.0
+
+        candidate_indices = flat_indices[np.argsort(need_surface.ravel())[::-1]]
+        candidate_indices = candidate_indices[:candidate_count]
+
+        best_step: Optional[OptimisationStep] = None
+        best_result: Optional[SimulationResult] = None
+        best_mask: Optional[np.ndarray] = None
+
+        for idx in candidate_indices:
+            candidate_mask = make_structured_candidate(idx, current_parks.shape, kernel_size=kernel_size)
+            result = simulate_park(
+                current_lst,
+                current_no2,
+                current_pw,
+                pop,
+                vulnerability,
+                current_parks,
+                candidate_mask,
+                lambda_m=lambda_m,
+                lambda_o=lambda_o,
+            )
+            if result is None:
+                continue
+
+            summary = ScoreSummary.from_surfaces(result.hcs_after, result.equity_after)
+            step = OptimisationStep(
+                index=int(idx),
+                equity_delta=result.mean_equity_delta,
+                marginal_gain=result.marginal_gain,
+                coverage_gain=float(np.nanmean(result.coverage_gain)),
+                maintenance_penalty=result.maintenance_penalty,
+                overlap_penalty=result.overlap_penalty,
+                summary=summary,
+            )
+
+            if best_step is None or step.marginal_gain > best_step.marginal_gain:
+                best_step = step
+                best_result = result
+                best_mask = candidate_mask
+
+        if best_step is None or best_step.marginal_gain <= 0:
+            break
+
+        steps.append(best_step)
+        current_lst = best_result.lst_new
+        current_no2 = best_result.no2_new
+        current_pw = best_result.pwv_new
+        current_parks = current_parks | best_mask
+
+    return OptimisationResult(steps=steps)

--- a/backend/utils/scoring.py
+++ b/backend/utils/scoring.py
@@ -1,0 +1,69 @@
+"""Scoring utilities for the Healthy City Score backend."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+
+# Default weights for the Healthy City Score components.
+HEAT_WEIGHT = 0.4
+AIR_WEIGHT = 0.4
+MOISTURE_WEIGHT = 0.2
+
+
+def zscore(data: np.ndarray) -> np.ndarray:
+    """Return the z-score normalisation of an array.
+
+    Parameters
+    ----------
+    data:
+        Array containing the values to normalise.
+
+    Returns
+    -------
+    np.ndarray
+        Z-score normalised array where NaN values are preserved.
+    """
+
+    mean = np.nanmean(data)
+    std = np.nanstd(data) + 1e-9
+    return (data - mean) / std
+
+
+def compute_hcs(
+    lst: np.ndarray,
+    no2: np.ndarray,
+    pwv: np.ndarray,
+    *,
+    weights: Tuple[float, float, float] = (HEAT_WEIGHT, AIR_WEIGHT, MOISTURE_WEIGHT),
+) -> np.ndarray:
+    """Compute the Healthy City Score (HCS) surface."""
+
+    w_h, w_a, w_m = weights
+    lst_z = zscore(lst)
+    no2_z = zscore(no2)
+    pwv_z = zscore(pwv)
+    return 100.0 - (w_h * lst_z + w_a * no2_z + w_m * pwv_z)
+
+
+def equity_adjust(hcs: np.ndarray, vulnerability: np.ndarray, equity_weight: float = 0.4) -> np.ndarray:
+    """Apply the equity adjustment using the vulnerability surface."""
+
+    return hcs * (1.0 - equity_weight * vulnerability)
+
+
+@dataclass
+class ScoreSummary:
+    """Container for summary statistics."""
+
+    hcs_mean: float
+    equity_mean: float
+
+    @classmethod
+    def from_surfaces(cls, hcs: np.ndarray, equity: np.ndarray) -> "ScoreSummary":
+        return cls(
+            hcs_mean=float(np.nanmean(hcs)),
+            equity_mean=float(np.nanmean(equity)),
+        )

--- a/backend/utils/simulation.py
+++ b/backend/utils/simulation.py
@@ -1,0 +1,178 @@
+"""Simulation utilities for adding parks and updating rasters."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+from scipy.ndimage import distance_transform_edt
+
+from .scoring import compute_hcs, equity_adjust
+
+
+@dataclass
+class SimulationResult:
+    """Container with the updated rasters and diagnostics."""
+
+    lst_new: np.ndarray
+    no2_new: np.ndarray
+    pwv_new: np.ndarray
+    delta_lst: np.ndarray
+    delta_no2: np.ndarray
+    need: np.ndarray
+    coverage_before: np.ndarray
+    coverage_after: np.ndarray
+    coverage_gain: np.ndarray
+    hcs_before: np.ndarray
+    hcs_after: np.ndarray
+    equity_before: np.ndarray
+    equity_after: np.ndarray
+    mean_equity_delta: float
+    maintenance_penalty: float
+    overlap_penalty: float
+    marginal_gain: float
+
+
+def _normalise(array: np.ndarray) -> np.ndarray:
+    array = np.array(array, dtype=float)
+    if np.all(np.isnan(array)):
+        return np.zeros_like(array)
+    max_val = np.nanmax(array)
+    if max_val <= 0:
+        return np.zeros_like(array)
+    return array / (max_val + 1e-9)
+
+
+def compute_need(
+    pop: np.ndarray,
+    vulnerability: np.ndarray,
+    parks_mask: np.ndarray,
+    *,
+    px_m: float = 1000.0,
+    service_radius: float = 300.0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute the need surface and service coverage."""
+
+    if parks_mask.dtype != bool:
+        parks_mask = parks_mask.astype(bool)
+
+    # Distance (in pixels) to the nearest park cell.
+    distance = distance_transform_edt(~parks_mask)
+    coverage = np.exp(-distance * px_m / service_radius)
+
+    pop_weight = _normalise(pop)
+    vuln_weight = np.nan_to_num(vulnerability, nan=0.0)
+    need = pop_weight * (1.0 + vuln_weight) * (1.0 - coverage)
+
+    return need, coverage
+
+
+def _cap_delta(delta: np.ndarray, lower: float) -> np.ndarray:
+    """Ensure deltas are capped to a minimum negative value."""
+
+    result = np.clip(delta, lower, 0.0)
+    return result
+
+
+def simulate_park(
+    lst: np.ndarray,
+    no2: np.ndarray,
+    pwv: np.ndarray,
+    pop: np.ndarray,
+    vulnerability: np.ndarray,
+    parks_mask: np.ndarray,
+    new_park_mask: np.ndarray,
+    *,
+    pixel_size_m: float = 1000.0,
+    service_radius: float = 300.0,
+    c_max: float = 1.0,
+    r0_heat: float = 300.0,
+    r_max: float = 0.05,
+    r0_no2: float = 150.0,
+    lambda_m: float = 0.5,
+    lambda_o: float = 2.0,
+) -> Optional[SimulationResult]:
+    """Simulate the impact of a new park polygon."""
+
+    parks_mask = parks_mask.astype(bool)
+    new_mask = new_park_mask.astype(bool)
+    net_new = new_mask & (~parks_mask)
+
+    if net_new.sum() == 0:
+        return None
+
+    need, coverage_before = compute_need(
+        pop, vulnerability, parks_mask, px_m=pixel_size_m, service_radius=service_radius
+    )
+
+    # Cooling impact (ΔLST)
+    distance_new = distance_transform_edt(~net_new)
+    cool_kernel = np.exp(-distance_new * pixel_size_m / r0_heat)
+    delta_lst = -c_max * cool_kernel * need
+    delta_lst = _cap_delta(delta_lst, lower=-2.0)
+
+    # Air quality impact (ΔNO2)
+    no2_kernel = np.exp(-distance_new * pixel_size_m / r0_no2)
+    delta_no2 = -r_max * no2 * no2_kernel * need
+    delta_no2 = np.maximum(delta_no2, -0.10 * no2)
+
+    lst_new = lst + delta_lst
+    no2_new = no2 + delta_no2
+    pwv_new = np.array(pwv, copy=True)
+
+    parks_after = parks_mask | net_new
+    need_after, coverage_after = compute_need(
+        pop, vulnerability, parks_after, px_m=pixel_size_m, service_radius=service_radius
+    )
+    coverage_gain = coverage_after - coverage_before
+
+    # Scores and penalties
+    hcs_before = compute_hcs(lst, no2, pwv)
+    hcs_after = compute_hcs(lst_new, no2_new, pwv_new)
+    equity_before = equity_adjust(hcs_before, vulnerability)
+    equity_after = equity_adjust(hcs_after, vulnerability)
+    mean_equity_delta = float(np.nanmean(equity_after - equity_before))
+
+    maintenance_penalty = float(lambda_m)
+    overlap_penalty = float(lambda_o * np.nanmean(np.clip(coverage_gain, 0.0, 1.0)))
+    marginal_gain = mean_equity_delta - maintenance_penalty - overlap_penalty
+
+    return SimulationResult(
+        lst_new=lst_new,
+        no2_new=no2_new,
+        pwv_new=pwv_new,
+        delta_lst=delta_lst,
+        delta_no2=delta_no2,
+        need=need,
+        coverage_before=coverage_before,
+        coverage_after=coverage_after,
+        coverage_gain=coverage_gain,
+        hcs_before=hcs_before,
+        hcs_after=hcs_after,
+        equity_before=equity_before,
+        equity_after=equity_after,
+        mean_equity_delta=mean_equity_delta,
+        maintenance_penalty=maintenance_penalty,
+        overlap_penalty=overlap_penalty,
+        marginal_gain=marginal_gain,
+    )
+
+
+def make_structured_candidate(
+    index: int,
+    shape: Tuple[int, int],
+    kernel_size: int = 3,
+) -> np.ndarray:
+    """Create a small square mask centred on the index."""
+
+    rows, cols = shape
+    mask = np.zeros(shape, dtype=bool)
+    r = index // cols
+    c = index % cols
+    half = kernel_size // 2
+    r0 = max(r - half, 0)
+    r1 = min(r + half + 1, rows)
+    c0 = max(c - half, 0)
+    c1 = min(c + half + 1, cols)
+    mask[r0:r1, c0:c1] = True
+    return mask

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,7 @@ folium>=0.12.0
 # Backend API server
 flask>=2.0.0
 flask-cors>=3.0.0
+fastapi>=0.95.0
+uvicorn[standard]>=0.20.0
+rioxarray>=0.15.0
+shapely>=2.0.0


### PR DESCRIPTION
## Summary
- introduce a FastAPI-based backend that loads NASA rasters (or mock fallbacks) and exposes scoring, simulation, and optimisation endpoints
- add park impact modelling utilities for need, coverage saturation, and marginal gain calculations with diminishing returns controls
- provide a greedy optimiser to estimate the number of parks that improve equity-adjusted scores before benefits decline

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e21cf8ae3883288d121dfbc96f2c49